### PR TITLE
fix: prevent duplicate Direct channels (race condition)

### DIFF
--- a/Chat.Domain/Common/IUnitOfWork.Transaction.cs
+++ b/Chat.Domain/Common/IUnitOfWork.Transaction.cs
@@ -1,0 +1,13 @@
+using System.Data;
+
+namespace Chat.Domain.Common;
+
+public interface ITransaction : IAsyncDisposable
+{
+    Task CommitAsync();
+}
+
+public partial interface IUnitOfWork
+{
+    Task<ITransaction> BeginTransactionAsync(IsolationLevel isolationLevel);
+}

--- a/Chat.Domain/Services/ChannelService/ChannelService.cs
+++ b/Chat.Domain/Services/ChannelService/ChannelService.cs
@@ -1,4 +1,5 @@
-﻿using Chat.Domain.Common;
+﻿using System.Data;
+using Chat.Domain.Common;
 using Chat.Domain.Entities.Accounts;
 using Chat.Domain.Entities.Accounts.AIBots;
 using Chat.Domain.Entities.Channels;
@@ -21,6 +22,10 @@ public class ChannelBS : DomainService
         int? aiProfileId = null
     )
     {
+        await using ITransaction transaction = await _unitOfWork.BeginTransactionAsync(
+            IsolationLevel.Serializable
+        );
+
         ISingleSpecification<Account> specification =
             aiProfileId == null
                 ? new AccountByIdSpec(secondAccountId, true)
@@ -67,6 +72,7 @@ public class ChannelBS : DomainService
 
         await _unitOfWork.Channel.AddAsync(channel);
         await _unitOfWork.SaveChangesAsync();
+        await transaction.CommitAsync();
 
         return channel;
     }

--- a/Chat.Persistence/UnitOfWork/UnitOfWork.Transaction.cs
+++ b/Chat.Persistence/UnitOfWork/UnitOfWork.Transaction.cs
@@ -1,0 +1,21 @@
+using System.Data;
+using Chat.Domain.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Chat.Persistence.UnitOfWork;
+
+public partial class UnitOfWork
+{
+    public async Task<ITransaction> BeginTransactionAsync(IsolationLevel isolationLevel)
+    {
+        IDbContextTransaction transaction = await _eFContext.Database.BeginTransactionAsync(isolationLevel);
+        return new TransactionWrapper(transaction);
+    }
+
+    private class TransactionWrapper(IDbContextTransaction transaction) : ITransaction
+    {
+        public Task CommitAsync() => transaction.CommitAsync();
+        public ValueTask DisposeAsync() => transaction.DisposeAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- Wrap Direct channel creation in Serializable transaction
- Prevents TOCTOU race condition where two concurrent requests create duplicate channels
- Extract transaction logic into separate partial files (IUnitOfWork.Transaction.cs, UnitOfWork.Transaction.cs)

## Test plan
- [ ] Create Direct channel with same user from two clients simultaneously — second should get error