### PR TITLE
Backend performance & reliability fixes

### DIFF
--- a/Chat.Application/Services/ChatService/ChatService.cs
+++ b/Chat.Application/Services/ChatService/ChatService.cs
@@ -130,7 +130,7 @@ public class ChatService : BaseService, IChatService
     {
         int accountId = request.IsAIBot ? await _chatBS.GetAIBotId() : AccountId;
 
-        IEnumerable<Message> readMessages = await _chatBS.ReadMessagesAsync(
+        List<int> readMessageIds = await _chatBS.ReadMessagesAsync(
             request.ChannelId,
             request.MessageId,
             accountId
@@ -148,7 +148,7 @@ public class ChatService : BaseService, IChatService
 
         return new ChatServiceReadMessageResponse()
         {
-            ReadMessageIds = readMessages.Select(message => message.Id),
+            ReadMessageIds = readMessageIds,
             UserIds = userIds,
             UnreadMessagesCount = unreadMessagesCount
         };

--- a/Chat.Domain/Entities/Channels/Messages/IMessageRepository.cs
+++ b/Chat.Domain/Entities/Channels/Messages/IMessageRepository.cs
@@ -8,4 +8,10 @@ public interface IMessageRepository : IAsyncRepository<Message>
         IEnumerable<int> channelIds,
         int accountId
     );
+
+    Task<List<int>> BatchReadMessagesAsync(
+        int channelId,
+        int lastMessageId,
+        int accountId
+    );
 }

--- a/Chat.Domain/Services/ChatService/ChatService.cs
+++ b/Chat.Domain/Services/ChatService/ChatService.cs
@@ -62,34 +62,17 @@ public class ChatBS : DomainService
         return message;
     }
 
-    public async Task<IEnumerable<Message>> ReadMessagesAsync(
+    public async Task<List<int>> ReadMessagesAsync(
         int channelId,
         int lastMessageId,
         int accountId
     )
     {
-        IEnumerable<Message>? unreadMessages = await _unitOfWork
-            .Message
-            .GetAllAsync(new UnreadMessagesSpec(channelId, lastMessageId, accountId));
-
-        if (unreadMessages == null)
-            throw new NotExistsException("Messages not exists");
-
-        Account account =
-            await _unitOfWork.Account.GetAsync(new AccountByIdSpec(accountId, true))
-            ?? throw new NotExistsException("Account not found");
-
-        foreach (Message message in unreadMessages)
-        {
-            message.Read();
-            message.AddReadAccounts(account);
-        }
-
-        var readMessages = unreadMessages.ToList();
-
-        await _unitOfWork.SaveChangesAsync();
-
-        return readMessages;
+        return await _unitOfWork.Message.BatchReadMessagesAsync(
+            channelId,
+            lastMessageId,
+            accountId
+        );
     }
 
     public async Task<Message> AddMessageAsync(

--- a/Chat.Persistence/Repositories/MessageRepository.cs
+++ b/Chat.Persistence/Repositories/MessageRepository.cs
@@ -8,8 +8,49 @@ namespace Chat.Persistence.Repositories;
 
 public class MessageRepository : BaseRepository<Message>, IMessageRepository
 {
+    private readonly EFContext _dbContext;
+
     public MessageRepository(EFContext dbContext)
-        : base(dbContext) { }
+        : base(dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<List<int>> BatchReadMessagesAsync(
+        int channelId,
+        int lastMessageId,
+        int accountId
+    )
+    {
+        List<int> unreadMessageIds = await _dbSet
+            .Where(message =>
+                message.ChannelId == channelId
+                && message.Id <= lastMessageId
+                && message.ReadAccounts.All(account => account.Id != accountId)
+                && message.AuthorId != accountId)
+            .Select(message => message.Id)
+            .ToListAsync();
+
+        if (unreadMessageIds.Count == 0)
+            return unreadMessageIds;
+
+        await _dbSet
+            .Where(message => unreadMessageIds.Contains(message.Id))
+            .ExecuteUpdateAsync(setters =>
+                setters.SetProperty(m => m.IsRead, true));
+
+        List<Dictionary<string, object>> joinEntries = [.. unreadMessageIds.Select(messageId => new Dictionary<string, object>
+        {
+            ["ReadMessagesId"] = messageId,
+            ["ReadAccountsId"] = accountId
+        })];
+
+        _dbContext.Set<Dictionary<string, object>>("AccountMessage").AddRange(joinEntries);
+
+        await _dbContext.SaveChangesAsync();
+
+        return unreadMessageIds;
+    }
 
     public async Task<Dictionary<int, ChannelSummary>> GetChannelSummariesAsync(
         IEnumerable<int> channelIds,


### PR DESCRIPTION
## Summary
- Batch update for ReadMessages (ExecuteUpdate + AddRange instead of N individual updates)
- Wrap Direct channel creation in Serializable transaction (race condition fix)
- Add composite index on Messages(ChannelId, CreatedAt DESC)
- Remove eager loading of all messages in AccountChannelsSpec
- Move pagination from in-memory to DB level via IQueryable
- Cleanup: remove unused publish-image script, .doc directory, disable file logging

## Test plan
- [ ] Verify read messages marking works correctly in chat
- [ ] Verify channel list loads without performance degradation
- [ ] Verify message pagination works correctly
- [ ] Verify direct channel creation doesn't produce duplicates under concurrency