### PR TITLE
feat: case-insensitive search and fix public channel join

### DIFF
--- a/Chat.Domain/Entities/Accounts/AccountSpecification.cs
+++ b/Chat.Domain/Entities/Accounts/AccountSpecification.cs
@@ -37,7 +37,7 @@ public class AccountsSpec : Specification<Account>
             (account) =>
                 account.Id != accountId
                 && account.Role != AccountRole.AIBot
-                && (searchField == null || account.Login.Contains(searchField))
+                && (searchField == null || account.Login.ToLower().Contains(searchField.ToLower()))
         )
     {
         ApplyOrderBy(account => account.Id);

--- a/Chat.Domain/Entities/Channels/ChannelSpecification.cs
+++ b/Chat.Domain/Entities/Channels/ChannelSpecification.cs
@@ -11,7 +11,8 @@ public class PublicChannelsSpec : Specification<Channel>
                 channel.Type == ChannelType.Public
                 && (
                     searchField == null
-                    || channel.Name != null && channel.Name.Contains(searchField)
+                    || channel.Name != null
+                        && channel.Name.ToLower().Contains(searchField.ToLower())
                 )
         )
     {
@@ -75,4 +76,14 @@ public class ChannelByIdSpec : Specification<Channel>
 {
     public ChannelByIdSpec(int? id)
         : base((channel) => channel.Id == id) { }
+}
+
+public class ChannelByIdWithAccountsSpec : Specification<Channel>
+{
+    public ChannelByIdWithAccountsSpec(int id)
+        : base((channel) => channel.Id == id)
+    {
+        AddInclude(channel => channel.Accounts);
+        ApplyTracking();
+    }
 }

--- a/Chat.Domain/Services/ChannelService/ChannelService.cs
+++ b/Chat.Domain/Services/ChannelService/ChannelService.cs
@@ -178,7 +178,7 @@ public class ChannelBS : DomainService
             ?? throw new NotExistsException("Account not found");
 
         Channel channel =
-            await _unitOfWork.Channel.GetAsync(new ChannelByIdSpec(channelId))
+            await _unitOfWork.Channel.GetAsync(new ChannelByIdWithAccountsSpec(channelId))
             ?? throw new NotExistsException("Channel not found");
 
         if (channel.Type != ChannelType.Public || channel.Accounts.Contains(account))


### PR DESCRIPTION
## What's included

- Case-insensitive search for accounts and public channels (queries now match regardless of letter case)
- Fix: channel membership is now correctly persisted when a user joins a public channel

## Why

Users reported that searching for accounts or channels with mixed-case input returned no results, and that joining a public channel sometimes failed to save the membership record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)